### PR TITLE
fix: correct non-Montgomery wide-integer reduction on zkvm

### DIFF
--- a/risc0_wrapper/methods/guest/src/bin/wrapper.rs
+++ b/risc0_wrapper/methods/guest/src/bin/wrapper.rs
@@ -16,6 +16,38 @@
 
 risc0_zkvm::guest::entry!(main);
 
+
+fn test_from_bytes_wide_non_mont_reduction() {
+    // LE 512-bit integer confined to the low 64 bits must match Scalar::from(u64).
+    let mut lo = [0u8; 64];
+    lo[0] = 42;
+    assert_eq!(
+        bls12_381::Scalar::from_bytes_wide(&lo),
+        bls12_381::Scalar::from(42u64)
+    );
+
+    // Integer 3 * 2^256: only limb at byte offset 32 set to 3.
+    // Non-Mont path: d0=0, d1=3 → 3*R. Wrong Mont leftover would yield 3*R^2.
+    let mut hi = [0u8; 64];
+    hi[32] = 3;
+    let s_hi = bls12_381::Scalar::from_bytes_wide(&hi);
+
+    let mut one_shift = [0u8; 64];
+    one_shift[32] = 1;
+    let shift = bls12_381::Scalar::from_bytes_wide(&one_shift);
+    assert_eq!(s_hi, shift + shift + shift);
+
+    // Combined 7 + 2^256
+    let mut both = [0u8; 64];
+    both[0] = 7;
+    both[32] = 1;
+    assert_eq!(
+        bls12_381::Scalar::from_bytes_wide(&both),
+        bls12_381::Scalar::from(7u64) + shift
+    );
+}
+
+
 fn test_pairing_result_against_relic() {
     let a = bls12_381::G1Affine::generator();
     let b = bls12_381::G2Affine::generator();
@@ -120,4 +152,5 @@ fn test_pairing_result_against_relic() {
 
 fn main() {
     test_pairing_result_against_relic();
+    test_from_bytes_wide_non_mont_reduction();
 }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -316,8 +316,12 @@ impl Fp {
         #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         return d0 * R2 + d1 * R3;
 
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] //TODO: untested
-        return d0 * R + d1 * R2;
+        // Non-Montgomery: interpret the 768-bit integer as d0 + d1 * 2^384.
+        // R holds 2^384 mod p in canonical form, so this is d0 + d1 * R.
+        // (The previous `d0 * R + d1 * R2` form was a leftover of the Montgomery
+        // reduction identity and is off by a factor of R; see PR discussion.)
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        return d0 + d1 * R;
     }
 
     /// Returns whether or not this element is strictly lexicographically

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -414,8 +414,12 @@ impl Scalar {
         #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         return d0 * R2 + d1 * R3;
 
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] //TODO: untested
-        return d0 * R + d1 * R2;
+        // Non-Montgomery: interpret the 512-bit integer as d0 + d1 * 2^256.
+        // R holds 2^256 mod q in canonical form, so this is d0 + d1 * R.
+        // (The previous `d0 * R + d1 * R2` form was a leftover of the Montgomery
+        // reduction identity and is off by a factor of R.)
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        return d0 + d1 * R;
     }
 
     /// Converts from an integer represented in little endian


### PR DESCRIPTION
## Summary

On the zkVM path, `Fp` / `Scalar` are stored in **canonical (non-Montgomery)** form and use plain modular multiplication via `risc0-bigint2`. Wide-integer reductions must therefore map a high/low split `(d0, d1)` to:

```text
d0 + d1 * 2^k
```

The previous zkVM implementation used the **Montgomery** identity:

```text
d0 * R + d1 * R²
```

which is **off by a factor of R** in non-Montgomery arithmetic (algebraically: `wrong ≡ correct * R (mod p)`).

Both sites were marked `//TODO: untested`:

- `Fp::from_u768` (used by `Fp::random` / 768-bit reduction)
- `Scalar::from_u512` (used by `Scalar::from_bytes_wide`)

## Fix

```rust
// before (wrong for non-Mont)
return d0 * R + d1 * R2;

// after
return d0 + d1 * R;
```

## Tests

- Guest regression in `risc0_wrapper` for `Scalar::from_bytes_wide`:
  - low limb only ≡ `Scalar::from(u64)`
  - high limb only ≡ `3 * (1 << 256)` via additive check
  - combined `7 + 2^256`

## Related finding (Taiko / raiko2 production)

Separately, we observed **intermittent false-negative** KZG **blob proof-of-equivalence** verification inside the RISC0 zkVM when raiko2 guests patch crates-io `bls12_381` to `bls12_381/v0.8.0-risczero.1` for kzg-rs:

| Environment | mainnet proposal blob 20544 | blob 20535 |
|---|---|---|
| Host c-kzg gen + host kzg-rs | PASS | PASS |
| R0 guest **with** this patch | **FAIL** | PASS |
| R0 guest **without** bls12_381 patch | PASS | PASS |
| R0 guest bls patch only (no sha2 patch) | **FAIL** | PASS |

So the production failure is **zkVM + this crate**, not beacon/host proof generation. Upstream guest coverage today only checks `pairing(G1::generator(), G2::generator())` against a fixed vector — not KZG / random points / poly eval.

This PR fixes the clear `TODO: untested` wide-reduction bug. **It may not fully resolve the KZG PoE false negatives**; those likely need additional non-Montgomery coverage (pairing with compressed points, poly eval over roots of unity). Happy to help land a KZG regression if useful.

Reproduction notes / fixtures available from Taiko canary work (proposal 20544 / 20535).

## Test plan

- [ ] `cargo test` on host (existing suite)
- [ ] Build and run `risc0_wrapper` guest test (`test_from_bytes_wide_non_mont_reduction` + existing generator pairing)
- [ ] (optional) Re-run KZG PoE guest A/B with this commit as the bls12_381 pin